### PR TITLE
(fix) - check reloads before pushing to array

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,9 @@ export function hotmods (opts, listener) {
     }
 
     const reloads = Array.from(new Set(Object.values(mods).reduce((reloads, hotmod) => {
-      reloads.push(...hotmod.reloads)
+      if (Array.isArray(hotmod.reloads)) {
+        reloads.push(...hotmod.reloads)
+      }
       return reloads
     }, [])))
 


### PR DESCRIPTION
This PR fixes an error where `hotmod.reloads` was `null` so was causing the app to crash in dev mode.